### PR TITLE
[feature] allow passing client UID to faraday configuration

### DIFF
--- a/lib/avatax/configuration.rb
+++ b/lib/avatax/configuration.rb
@@ -19,7 +19,8 @@ module AvaTax
       :custom_logger_options,
       :proxy,
       :faraday_response,
-      :response_big_decimal_conversion
+      :response_big_decimal_conversion,
+      :client_uid
     ].freeze
 
     DEFAULT_APP_NAME = nil
@@ -36,6 +37,7 @@ module AvaTax
     DEFAULT_PROXY = nil
     DEFAULT_FARADAY_RESPONSE = false
     DEFAULT_RESPONSE_BIG_DECIMAL_CONVERSION = false
+    DEFAULT_CLIENT_UID = nil
 
     attr_accessor *VALID_OPTIONS_KEYS
 
@@ -70,6 +72,7 @@ module AvaTax
       self.proxy = DEFAULT_PROXY
       self.faraday_response = DEFAULT_FARADAY_RESPONSE
       self.response_big_decimal_conversion = DEFAULT_RESPONSE_BIG_DECIMAL_CONVERSION
+      self.client_uid = DEFAULT_CLIENT_UID
     end
 
   end

--- a/lib/avatax/connection.rb
+++ b/lib/avatax/connection.rb
@@ -14,7 +14,8 @@ module AvaTax
           {
            'Accept' => "application/json; charset=utf-8",
            'User-Agent' => user_agent,
-           'X-Avalara-Client' => client_id
+           'X-Avalara-Client' => client_id,
+           'X-Avalara-UID' => client_uid
           },
         :url => endpoint,
         :proxy => proxy


### PR DESCRIPTION
Wanted to add `X-Avalara-UID` to the headers to comply with Avalara request.

Example: 
```
X-Avalara-Client: xxxxx;[Version];REST;V2;[MachineName]
X-Avalara-UID: xxxxxxxxx
```