### PR TITLE
Use inline Oj settings when necessary

### DIFF
--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -4,6 +4,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake', '~> 12.0.0')
   s.add_development_dependency('rspec', '~> 3.5.0')
   s.add_development_dependency('webmock', '>= 2.0.0')
+  s.add_development_dependency('pry')
   s.add_runtime_dependency('faraday', '>= 0.10')
   s.add_runtime_dependency('faraday_middleware', '>= 0.10')
   s.add_runtime_dependency('multi_json', '>= 1.0.3')

--- a/lib/avatax/api.rb
+++ b/lib/avatax/api.rb
@@ -3,7 +3,6 @@ require File.expand_path('../request', __FILE__)
 
 module AvaTax
   class API
-
     attr_accessor *Configuration::VALID_OPTIONS_KEYS
 
     def initialize(options={})

--- a/spec/avatax/api_spec.rb
+++ b/spec/avatax/api_spec.rb
@@ -1,0 +1,30 @@
+require_relative "../spec_helper"
+
+describe AvaTax::API do
+  context "connection" do
+
+    it "uses custom ParseOj for regular config" do
+      faraday_instance_double = double.as_null_object
+
+      expect(Faraday).to receive(:new).and_yield(faraday_instance_double)
+      expect(faraday_instance_double).to receive(:response).with(:oj, { content_type: /\bjson$/ })
+
+      # default setting
+      expect(Oj.default_options[:bigdecimal_load]).to eq(:auto)
+
+      AvaTax::API.new.send(:connection)
+    end
+
+    it "uses custom ParseOjWithBigDecimal when response_big_decimal_conversion provided" do
+      faraday_instance_double = double.as_null_object
+
+      expect(Faraday).to receive(:new).and_yield(faraday_instance_double)
+      expect(faraday_instance_double).to receive(:response).with(:oj_with_bigdecimal, { content_type: /\bjson$/ })
+
+      # default setting
+      expect(Oj.default_options[:bigdecimal_load]).to eq(:auto)
+
+      AvaTax::API.new(response_big_decimal_conversion: true).send(:connection)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,6 @@ companies = client.query_companies
 RSpec.configure do |config|
   config.before {
     @client = client
-    @company_code = companies["value"][0]["companyCode"]
+    @company_code = companies.dig("value", 0, "companyCode")
   }
 end


### PR DESCRIPTION
Setting `Oj.default_options` global setting causes unexpected sid effects for applications where gem is being included. Instead the `bigdecimal_load: :bigdecimal` mode can be applied inline. 