### PR TITLE
[internal] Move faraday_middleware_parse_oj into AvaTax gem

### DIFF
--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -1,14 +1,14 @@
 require File.expand_path('../lib/avatax/version', __FILE__)
 
 Gem::Specification.new do |s|
+  s.add_development_dependency('pry')
   s.add_development_dependency('rake', '~> 12.0.0')
   s.add_development_dependency('rspec', '~> 3.5.0')
   s.add_development_dependency('webmock', '>= 2.0.0')
-  s.add_development_dependency('pry')
-  s.add_runtime_dependency('faraday', '>= 0.10')
+  s.add_runtime_dependency('faraday', '>= 0.10', '< 2.0')
   s.add_runtime_dependency('faraday_middleware', '>= 0.10')
   s.add_runtime_dependency('multi_json', '>= 1.0.3')
-  s.add_runtime_dependency('faraday_middleware-parse_oj', '~> 0.3.2')
+  s.add_runtime_dependency('oj', '>= 3.0')
   s.authors = ["Marcus Vorwaller"]
   s.description = %q{A Ruby wrapper for the AvaTax REST and Search APIs}
   s.post_install_message =<<eos


### PR DESCRIPTION
Up to this date, we have been using a middleware added by https://github.com/7even/faraday_middleware-parse_oj. It wasn't updated in a long time and it still requires the `faraday` version to be `~> 0.9` which is one of the blockers of Ruby 3.0 for the main Chargify app.

Since this is a simple class, I've added it to our fork of AvaTax so that we can get rid of the faraday version restriction.

For now, if we update AvaTax in the main app (after this PR is merged), Faraday won't be updated - there are a few other gems that needed to be updated first. I've setup locally an environment with updated Faraday and calculating taxing was working correctly.